### PR TITLE
chore: Start.gg APIトークンを更新

### DIFF
--- a/libs/getStreamQueue.ts
+++ b/libs/getStreamQueue.ts
@@ -158,7 +158,7 @@ export const getStreamQueue = async (url?: string): Promise<StreamQueue> => {
   const res = await fetch(`https://api.smash.gg/gql/alpha`, {
     method: "POST",
     headers: {
-      Authorization: "Bearer b27e9778c425efba77751add00796217",
+      Authorization: "Bearer 2d1a68f32b1baf8b2b25aae5569f9dca",
       "Content-Type": "application/json",
       Accept: "application/json",
       encoding: "utf-8",
@@ -248,7 +248,7 @@ export const getStreamQueue = async (url?: string): Promise<StreamQueue> => {
       const res = await fetch(`https://api.smash.gg/gql/alpha`, {
         method: "POST",
         headers: {
-          Authorization: "Bearer b27e9778c425efba77751add00796217",
+          Authorization: "Bearer 2d1a68f32b1baf8b2b25aae5569f9dca",
           "Content-Type": "application/json",
           Accept: "application/json",
           encoding: "utf-8",


### PR DESCRIPTION
## Summary
- Start.gg APIの期限切れ間近のトークンを新しいものに更新しました

## 変更内容
- `libs/getStreamQueue.ts`内の2箇所のAPIトークンを更新
  - 旧トークン: `b27e9778c425efba77751add00796217`
  - 新トークン: `2d1a68f32b1baf8b2b25aae5569f9dca`