### PR TITLE
fix: Update API Endpoint URL and perPage in Query

### DIFF
--- a/libs/getAttendee.ts
+++ b/libs/getAttendee.ts
@@ -37,7 +37,7 @@ export const getAttendee = async (url?: string): Promise<Attendee> => {
       page: i,
     }
 
-    const res = await fetch(`https://api.smash.gg/gql/alpha`, {
+    const res = await fetch(`https://api.start.gg/gql/alpha`, {
       method: "POST",
       headers: {
         Authorization: "Bearer 2d1a68f32b1baf8b2b25aae5569f9dca",

--- a/libs/getEventInfo.ts
+++ b/libs/getEventInfo.ts
@@ -96,7 +96,7 @@ const fetchEventsInfo = async (variables: {
   phaseGroupId: string
   setsPage: number
 }): Promise<QueryResponse> => {
-  return await fetch(`https://api.smash.gg/gql/alpha`, {
+  return await fetch(`https://api.start.gg/gql/alpha`, {
     method: "POST",
     headers: {
       Authorization: "Bearer 2d1a68f32b1baf8b2b25aae5569f9dca",

--- a/libs/getStreamQueue.ts
+++ b/libs/getStreamQueue.ts
@@ -55,7 +55,7 @@ query StreamQueueOnTournament($tourneySlug: String!, $eventSlug: String!) {
     }
   }
   event(slug: $eventSlug) {
-    sets(perPage: 50, filters: {state: [1, 2], hideEmpty: true}) {
+    sets(perPage: 10, filters: {state: [1, 2], hideEmpty: true}) {
       pageInfo {
         totalPages
         total
@@ -86,7 +86,7 @@ query StreamQueueOnTournament($tourneySlug: String!, $eventSlug: String!) {
 const nextQuery = `
 query StreamQueueOnTournament($eventSlug: String!, $page: Int!) {
   event(slug: $eventSlug) {
-    sets(perPage: 50, page: $page, filters: {state: [1, 2], hideEmpty: true}) {
+    sets(perPage: 10, page: $page, filters: {state: [1, 2], hideEmpty: true}) {
       pageInfo {
         totalPages
         total
@@ -155,7 +155,7 @@ export const getStreamQueue = async (url?: string): Promise<StreamQueue> => {
     tourneySlug: tournarySlug,
     eventSlug: eventSlug,
   }
-  const res = await fetch(`https://api.smash.gg/gql/alpha`, {
+  const res = await fetch(`https://api.start.gg/gql/alpha`, {
     method: "POST",
     headers: {
       Authorization: "Bearer 2d1a68f32b1baf8b2b25aae5569f9dca",
@@ -245,7 +245,7 @@ export const getStreamQueue = async (url?: string): Promise<StreamQueue> => {
         eventSlug: eventSlug,
         page: i,
       }
-      const res = await fetch(`https://api.smash.gg/gql/alpha`, {
+      const res = await fetch(`https://api.start.gg/gql/alpha`, {
         method: "POST",
         headers: {
           Authorization: "Bearer 2d1a68f32b1baf8b2b25aae5569f9dca",

--- a/pages/obs/bracket.tsx
+++ b/pages/obs/bracket.tsx
@@ -85,7 +85,7 @@ const fullRoundText2Keys: { [key: string]: keyof BracketType } = {
 }
 
 const loadTop8Bracket = async (phaseGroupId: string) => {
-  const res = (await fetch("https://api.smash.gg/gql/alpha", {
+  const res = (await fetch("https://api.start.gg/gql/alpha", {
     method: "POST",
     headers: {
       Authorization: "Bearer 2d1a68f32b1baf8b2b25aae5569f9dca",


### PR DESCRIPTION
いつもお世話になってます！みずようかんです。
このプルリクエストは、
・古いAPIエンドポイントURLを更新
・BraceBracketを大規模なトーナメントで使用した際にStreamQueue関連のAPIコールが失敗するケースを修正・軽減
を行うものです。
例としましては、以下のようなトーナメントをBraceBracketで表示しようとした際に発生します。
https://www.start.gg/tournament/splashgo-test/event/qualifiers/brackets/1981028/2906130
APIコールが失敗する理由についてですが、Startgg側のレートリミット(レスポンスの複雑度が高すぎること)だと思われます。
そのため、APIをコールする際のperPageの値を下げ、Startgg側の規定した複雑度を下回るようにすることで改善します。
https://developer.start.gg/docs/rate-limits
<img width="750" height="144" alt="image" src="https://github.com/user-attachments/assets/f25c577a-1cdc-4bec-82af-105a32e4186f" />
このプルリクエストの内容にはほぼ破壊的な変更は無いはずですが、perPageの値を下げた分だけAPIのコール回数が増えることだけ留意していただければと思います。